### PR TITLE
feat(fn.cap): allow any cap limit, optimize cases

### DIFF
--- a/fn/cap.js
+++ b/fn/cap.js
@@ -1,6 +1,8 @@
 'use strict'
 
+const apply = require('./apply')
 const getType = require('../get-type')
+const toArray = require('../to/array')
 const isNumber = require('../is/number')
 
 module.exports = (fn, limit) => {
@@ -8,14 +10,18 @@ module.exports = (fn, limit) => {
     throw new TypeError(`Expected a function.`)
   }
 
-  limit = isNumber(limit) ? limit : fn.length || 0
+  limit = isNumber(limit) ? Math.abs(limit) : fn.length || 0
 
-  switch (limit) {
-    case 1: return a => fn(a)
-    case 2: return (a, b) => fn(a, b)
-    case 3: return (a, b, c) => fn(a, b, c)
-    case 4: return (a, b, c, d) => fn(a, b, c, d)
+  if (
+    ('length' in fn) &&
+    (fn.length < 1 ||
+    (fn.length > 0 && limit >= fn.length))
+  ) {
+    return fn
   }
-
-  return fn
+  
+  return function () {
+    let args = toArray(arguments, 0, limit)
+    return apply(fn, args)
+  }
 }

--- a/fn/cap.js
+++ b/fn/cap.js
@@ -19,7 +19,7 @@ module.exports = (fn, limit) => {
   ) {
     return fn
   }
-  
+
   return function () {
     let args = toArray(arguments, 0, limit)
     return apply(fn, args)


### PR DESCRIPTION
Allow any number as `limit` by working with the called argument array rather than just explicitly values 1-4. 

Optimize cases where the provided function already only accepts zero arguments or where the specified limit is equal to or greater than the function's `length` property (if it is present).