### PR TITLE
feat(util.reduce): rearrange argument order

### DIFF
--- a/tests/util/reduce.js
+++ b/tests/util/reduce.js
@@ -6,18 +6,18 @@ const array = [1, 2, 3, 4, 5]
 const string = 'foobar'
 
 test('reduces object inputs', t => {
-  let result = fn((acc, cur) => acc + cur, object, 0)
+  let result = fn((acc, cur) => acc + cur, 0, object)
   t.is(result, 6)
 })
 
 test('reduces array-like inputs', t => {
-  let result = fn((acc, cur) => acc + cur, array, 0)
+  let result = fn((acc, cur) => acc + cur, 0, array)
   t.is(result, 15)
 
   result = fn((acc, cur) => {
     acc.splice(0, 0, cur)
     return acc
-  }, string, [])
+  }, [], string)
 
   t.deepEqual(result, ['r', 'a', 'b', 'o', 'o', 'f'])
 })

--- a/util/reduce.js
+++ b/util/reduce.js
@@ -3,7 +3,7 @@
 const each = require('./each')
 const curry3 = require('../fn/curry3')
 
-module.exports = curry3((fn, collection, initial) => {
+module.exports = curry3((fn, initial, collection) => {
   let accumulator = initial
 
   each((v, k, o) => {


### PR DESCRIPTION
Swap the order of the `initial` and `collection` arguments.

BREAKING CHANGE: The argument order to `reduce()` has changed so the collection is last.