### PR TITLE
feat(col): add `match()` method

### DIFF
--- a/col/match.js
+++ b/col/match.js
@@ -12,6 +12,6 @@ module.exports = curry2((compare, object) => {
       return false
     }
   }, compare)
-  
+
   return match
 })

--- a/col/match.js
+++ b/col/match.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const each = require('./each')
+const isEqual = require('../is/equal')
+const curry2 = require('../fn/curry2')
+
+module.exports = curry2((compare, object) => {
+  let match = true
+  each((value, key) => {
+    if (!isEqual(value, object[key])) {
+      match = false
+      return false
+    }
+  }, compare)
+  
+  return match
+})

--- a/tests/col/match.js
+++ b/tests/col/match.js
@@ -1,0 +1,34 @@
+import test from 'ava'
+import fn from '../../col/match'
+
+test('returns true when specified properties match', t => {
+  let obj = { name: 'wishy', color: 'green' }
+  t.true(fn({ color: green }, obj))
+})
+
+test('returns false when specified properties do not match', t => {
+  let obj = { name: 'washy', color: 'red' }
+  t.false(fn({ color: blue }, obj))
+})
+
+test('auto-curried at two arguments', t => {
+  t.is(typeof fn({}), 'function')
+})
+
+test('effective as a predicate for Array#find()', t => {
+  let arr = [
+    { name: 'willy', color: 'red' },
+    { name: 'wally', color: 'red' },
+    { name: 'dopey', color: 'brown' },
+    { name: 'wishy', color: 'blue' },
+    { name: 'washy', color: 'green' }
+  ]
+
+  let res1 = arr.find(fn({ color: 'green' }))
+  let res2 = arr.find(fn({ color: 'brown' }))
+  let res3 = arr.find(fn({ color: 'red' }))
+
+  t.is(res1.name, 'washy')
+  t.is(res2.name, 'dopey')
+  t.is(res3.name, 'willy')
+})

--- a/tests/col/match.js
+++ b/tests/col/match.js
@@ -3,12 +3,12 @@ import fn from '../../col/match'
 
 test('returns true when specified properties match', t => {
   let obj = { name: 'wishy', color: 'green' }
-  t.true(fn({ color: green }, obj))
+  t.true(fn({ color: 'green' }, obj))
 })
 
 test('returns false when specified properties do not match', t => {
   let obj = { name: 'washy', color: 'red' }
-  t.false(fn({ color: blue }, obj))
+  t.false(fn({ color: 'blue' }, obj))
 })
 
 test('auto-curried at two arguments', t => {


### PR DESCRIPTION
Add `match()` for object property comparison. The curried version is useful as the predicate for native Array methods like `find()`.